### PR TITLE
Calling "Find-Module" during every install is a waste of time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-/.output
-/PSModules
-/.vscode
+/.output/
+/PSModules/
+/.vscode/
 /PxGet/CHANGELOG.md
 /PxGet/LICENSE
 /PxGet/NOTICE

--- a/PxGet/Functions/Get-PackageManagementPreference.ps1
+++ b/PxGet/Functions/Get-PackageManagementPreference.ps1
@@ -1,0 +1,25 @@
+
+function Get-PackageManagementPreference
+{
+    [CmdletBinding()]
+    param(
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $deepPrefs = @{}
+    if( (Test-Path -Path 'env:PXGET_DISABLE_DEEP_DEBUG') -and `
+        'Continue' -in @($Global:DebugPreference, $DebugPreference) )
+    {
+        $deepPrefs['Debug'] = $false
+    }
+
+    if( (Test-Path -Path 'env:PXGET_DISABLE_DEEP_VERBOSE') -and `
+        'Continue' -in @($Global:VerbosePreference, $VerbosePreference))
+    {
+        $deepPrefs['Verbose'] = $false
+    }
+
+    return $deepPrefs
+}

--- a/PxGet/Functions/Install-PrivateModule.ps1
+++ b/PxGet/Functions/Install-PrivateModule.ps1
@@ -1,0 +1,80 @@
+
+# Ugh. I hate this name, but it interferes with Install-Module in one of the package management modules.
+function Install-PrivateModule
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Configuration
+    )
+
+    begin
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        $pkgMgmtPrefs = Get-PackageManagementPreference
+    }
+
+    process
+    {
+        if( -not (Test-Path -Path $Configuration.LockPath) )
+        {
+            $Configuration | Update-ModuleLock
+        }
+
+        $repoByLocation = @{}
+        Get-PSRepository | ForEach-Object { $repoByLocation[$_.SourceLocation] = $_.Name }
+
+        $locks = Get-Content -Path $Configuration.LockPath | ConvertFrom-Json
+        $locks | Add-Member -Name 'PSModules' -MemberType NoteProperty -Value @() -ErrorAction Ignore
+        foreach( $module in $locks.PSModules )
+        {
+            $installedModules =
+                Get-Module -Name $module.name -ListAvailable -ErrorAction Ignore |
+                Add-Member -Name 'SemVer' -MemberType ScriptProperty -Value {
+                    $prerelease = $this.PrivateData['PSData']['PreRelease']
+                    if( $prerelease )
+                    {
+                        $prerelease = "-$($prerelease)"
+                    }
+                    return "$($this.Version)$($prerelease)"
+                }
+
+            $installedModule = $installedModules | Where-Object SemVer -EQ $module.version 
+            if( -not $installedModule )
+            {
+                $repoName = $repoByLocation[$module.location]
+                if( -not $repoName )
+                {
+                    $msg = "PowerShell repository at ""$($module.location)"" does not exist. Use " +
+                            '"Get-PSRepository" to see the current list of repositories, "Register-PSRepository" ' +
+                            'to add a new repository, or "Set-PSRepository" to update an existing repository.'
+                    Write-Error $msg
+                    continue
+                }
+
+                if( -not (Test-Path -Path $Configuration.PSModulesDirectoryName) )
+                {
+                    New-Item -Path $Configuration.PSModulesDirectoryName -ItemType 'Directory' -Force | Out-Null
+                }
+
+                Save-Module -Name $module.name `
+                            -Path $Configuration.PSModulesDirectoryName `
+                            -RequiredVersion $module.version `
+                            -AllowPrerelease `
+                            -Repository $repoName `
+                            @pkgMgmtPrefs
+            }
+
+            $modulePath = Join-Path -Path (Get-Location).Path -ChildPath $Configuration.PSModulesDirectoryName
+            $modulePath = Join-Path -Path $modulePath -ChildPath $module.name | Resolve-Path -Relative
+            [pscustomobject]@{
+                Name = $module.name;
+                Version = $module.version;
+                Path = $modulePath;
+                Location = $module.location;
+            } | Write-Output
+        }
+    }
+}

--- a/PxGet/Functions/Select-Module.ps1
+++ b/PxGet/Functions/Select-Module.ps1
@@ -2,21 +2,25 @@ function Select-Module
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory, ValueFromPipeline = $true)]
-        [PSCustomObject] $Module,
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Module,
 
         [Parameter(Mandatory)]
         [String] $Name,
 
-        [Parameter(Mandatory)]
-        [String] $Version,  
+        [String] $Version,
 
         [switch] $AllowPrerelease
     )
 
     process
     {
-        if( $Module.Name -ne $Name -or $Module.Version -notlike $Version )
+        if( $Module.Name -ne $Name )
+        {
+            return
+        }
+
+        if( $Version -and $Module.Version -notlike $Version )
         {
             return
         }

--- a/PxGet/Functions/Update-ModuleLock.ps1
+++ b/PxGet/Functions/Update-ModuleLock.ps1
@@ -1,0 +1,148 @@
+
+function Update-ModuleLock
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Configuration
+    )
+
+    begin
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        $pkgMgmtPrefs = Get-PackageManagementPreference
+    }
+
+    process
+    {
+        $modulesNotFound = [Collections.ArrayList]::New()
+        $moduleNames = $Configuration.PSModules | Select-Object -ExpandProperty 'Name'
+        if( -not $moduleNames )
+        {
+            Write-Warning "There are no modules listed in ""$($Path | Resolve-Path -Relative)""."
+            return
+        }
+
+        $numFinds = $moduleNames | Measure-Object | Select-Object -ExpandProperty 'Count'
+        $numFinds = $numFinds + 2
+        Write-Debug "  numSteps  $($numFinds)"
+        $curStep = 0
+        $uniqueModuleNames = $moduleNames | Select-Object -Unique
+        $status = "Find-Module -Name '$($uniqueModuleNames -join "', '")'"
+        $percentComplete = ($curStep++/$numFinds * 100)
+        $activity = @{ Activity = 'Resolving Module Versions' }
+        Write-Progress @activity -Status $status -PercentComplete $percentComplete
+
+        try
+        {
+            $modules = Find-Module -Name $uniqueModuleNames -ErrorAction Ignore @pkgMgmtPrefs
+            if( -not $modules )
+            {
+                $msg = "$($Path | Resolve-Path -Relative): Modules ""$($uniqueModuleNames -join '", "')"" not " +
+                       'found.'
+                Write-Error $msg
+                return
+            }
+
+            # Find-Module is expensive. Limit calls as much as possible.
+            $findModuleCache = @{}
+
+            $locks = [Collections.ArrayList]::New()
+
+            $env:PSModulePath =
+                Join-Path -Path $Configuration.File.DirectoryName -ChildPath $Configuration.PSModulesDirectoryName
+            foreach( $pxModule in $Configuration.PSModules )
+            {
+                $optionalParams = @{}
+
+                # Make sure these members are present and have default values.
+                $pxModule | Add-Member -Name 'Version' -MemberType NoteProperty -Value '' -ErrorAction Ignore
+                $pxModule |
+                    Add-Member -Name 'AllowPrerelease' -MemberType NoteProperty -Value $false -ErrorAction Ignore
+
+                $versionDesc = 'latest'
+                if( $pxModule.Version )
+                {
+                    $versionDesc = $optionalParams['Version'] = $pxModule.Version
+                }
+
+                $allowPrerelease = $false
+                if( $pxModule.AllowPrerelease -or $pxModule.Version -match '-' )
+                {
+                    $allowPrerelease = $optionalParams['AllowPrerelease'] = $true
+                }
+
+                $curStep += 1
+
+                Write-Debug "  curStep   $($curStep)"
+                $moduleToInstall =
+                    $modules | Select-Module -Name $pxModule.Name @optionalParams | Select-Object -First 1
+                if( -not $moduleToInstall )
+                {
+                    $status = "Find-Module -Name '$($pxModule.Name)' -AllVersions"
+                    if( $allowPrerelease )
+                    {
+                        $status = "$($status) -AllowPrerelease"
+                    }
+
+                    if( -not $findModuleCache.ContainsKey($status) )
+                    {
+                        Write-Progress @activity -Status $status -PercentComplete ($curStep/$numFinds * 100)
+                        $findModuleCache[$status] = Find-Module -Name $pxModule.Name `
+                                                                -AllVersions `
+                                                                -AllowPrerelease:$allowPrerelease `
+                                                                -ErrorAction Ignore `
+                                                                @pkgMgmtPrefs
+                    }
+                    $moduleToInstall =
+                        $findModuleCache[$status] |
+                        Select-Module -Name $pxModule.Name @optionalParams |
+                        Select-Object -First 1
+                }
+
+                if( -not $moduleToInstall )
+                {
+                    [void]$modulesNotFound.Add($pxModule.Name)
+                    continue
+                }
+
+                $pin = [pscustomobject]@{
+                    name = $moduleToInstall.Name;
+                    version = $moduleToInstall.Version;
+                    location = $moduleToInstall.RepositorySourceLocation;
+                }
+                [void]$locks.Add( $pin )
+                [pscustomobject]@{
+                    'ModuleName' = $pxModule.Name;
+                    'Version' = $versionDesc;
+                    'LockedVersion' = $pin.version;
+                    'Location' = $pin.location;
+                } | Write-Output
+            }
+
+            Write-Progress @activity -Status "Saving lock file ""$($Configuration.LockPath)""." -PercentComplete 100
+            $pxgetLock = [pscustomobject]@{
+                PSModules = $locks;
+            }
+            $pxgetLock | ConvertTo-Json -Depth 2 | Set-Content -Path $Configuration.LockPath -NoNewline
+
+            if( $modulesNotFound.Count )
+            {
+                $suffix = ''
+                if( $modulesNotFound.Count -gt 1 )
+                {
+                    $suffix = 's'
+                }
+                $msg = "$($Path | Resolve-Path -Relative): Module$($suffix) ""$($modulesNotFound -join '", "')"" not " +
+                       'found.'
+                Write-Error $msg
+            }
+        }
+        finally
+        {
+            Write-Progress @activity -Completed
+        }
+    }
+}

--- a/PxGet/PxGet.psd1
+++ b/PxGet/PxGet.psd1
@@ -18,7 +18,7 @@
     RootModule = 'PxGet.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.1.3'
+    ModuleVersion = '0.2.0'
 
     # ID used to uniquely identify this module
     GUID = '5b244346-40c9-4a50-a098-8758c19f7f25'

--- a/Tests/install.Tests.ps1
+++ b/Tests/install.Tests.ps1
@@ -1,0 +1,263 @@
+
+#Requires -Version 5.1
+Set-StrictMode -Version 'Latest'
+
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+
+    $script:testRoot  = $null
+    $script:moduleList = @()
+    $script:failed = $false
+    $script:testNum = 0
+    $script:origProgressPref = $Global:ProgressPreference
+    $script:origVerbosePref = $Global:VerbosePreference
+    $script:origDebugPref = $Global:DebugPreference
+    $Global:ProgressPreference = [Management.Automation.ActionPreference]::SilentlyContinue
+    $script:psgalleryLocation = Get-PSRepository -Name 'PSGallery' | Select-Object -ExpandProperty 'SourceLocation'
+    $script:latestNoOpLockFile = @"
+{
+    "PSModules": { "name": "NoOp", "version": "1.0.0", "location": "$($script:psgallerylocation)" }
+}
+"@
+
+    function GivenPxGetFile
+    {
+        param(
+            [Parameter(Mandatory)]
+            [String] $Contents
+        )
+
+        $Contents | Set-Content -Path 'pxget.json' -NoNewline
+    }
+
+    function GivenLockFile
+    {
+        param(
+            [Parameter(Mandatory)]
+            [String] $Contents
+        )
+
+        $Contents | Set-Content -Path 'pxget.lock.json' -NoNewline
+    }
+
+    function ThenInstalled
+    {
+        param(
+            [Parameter(Mandatory)]
+            [hashtable] $Module,
+
+            [String] $In = 'PSModules'
+        )
+
+        # Make sure *only* the modules we requested are installed.
+        $expectedCount = 0
+        foreach( $moduleName in $Module.Keys )
+        {
+            $modulePath = Join-Path -Path $In -ChildPath $moduleName
+            foreach( $semver in $Module[$moduleName] )
+            {
+                $expectedCount += 1
+                $version,$prerelease = $semver -split '-'
+                $manifestPath = Join-Path -Path $modulePath -ChildPath $version
+                $manifestPath = Join-Path -Path $manifestPath -ChildPath "$($moduleName).psd1"
+                $manifestPath | Should -Exist
+                $manifest =
+                    Test-ModuleManifest -Path $manifestPath |
+                    Add-Member -Name 'SemVer' -MemberType ScriptProperty -Value {
+                        $prerelease = $this.PrivateData['PSData']['PreRelease']
+                        if( $prerelease )
+                        {
+                            $prerelease = "-$($prerelease)"
+                        }
+                        return "$($this.Version)$($prerelease)"
+                    } -PassThru
+
+                $manifest | Should -Not -BeNullOrEmpty
+                $manifest.SemVer | Should -Be $semver
+            }
+        }
+        Get-ChildItem -Path "$($In)\*\*\*.psd1" -ErrorAction Ignore |
+            Select-Object -ExpandProperty 'DirectoryName' |
+            Select-Object -Unique |
+            Should -HaveCount $expectedCount
+    }
+    
+    function ThenSucceeded
+    {
+        $Global:Error | Should -BeNullOrEmpty
+    }
+    
+    function WhenInstalling
+    {
+        [CmdletBinding()]
+        param(
+        )
+
+        Invoke-PxGet -Command 'install' |
+            Format-Table |
+            Out-String |
+            Write-Verbose -Verbose
+    }
+}
+
+AfterAll {
+    $Global:ProgressPreference = $script:origProgressPref
+}
+
+Describe 'pxget install' {
+    BeforeEach { 
+        $script:testRoot = $null
+        $script:moduleList = @()
+        $script:failed = $false
+        $Global:Error.Clear()
+        $script:testRoot = Join-Path -Path $TestDrive -ChildPath ($script:testNum++)
+        New-Item -Path $script:testRoot -ItemType 'Directory'
+        Push-Location $script:testRoot
+    }
+
+    AfterEach {
+        $Global:DebugPreference = $script:origDebugPref
+        $Global:VerbosePreference = $script:origVerbosePref
+        Remove-Item -Path 'env:PXGET_*' -ErrorAction Ignore
+        Pop-Location
+    }
+
+    It 'should create lock and install module' {
+        GivenPxGetFile @"
+        {
+            "PSModules": [
+                {
+                    "Name": "NoOp",
+                    "Version": "1.0.0"
+                }
+            ]
+        }
+"@
+        WhenInstalling
+        ThenInstalled @{ 'NoOp' = '1.0.0' }
+        'pxget.lock.json' | Should -Exist
+        $expectedContent = ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{ name = 'NoOp'; version = '1.0.0'; location = $script:psgalleryLocation }
+            )}) | ConvertTo-Json
+        Get-Content -Path 'pxget.lock.json' -Raw | Should -Be $expectedContent
+    }
+
+    It 'should install multiple versions' {
+        GivenPxGetFile '{}' # install only cares about pxget.lock.json
+        GivenLockFile @"
+{
+    "PSModules": [
+        { "name": "Carbon", "version": "2.11.1", "location": "$($script:psgallerylocation)" },
+        { "name": "Carbon", "version": "2.11.0", "location": "$($script:psgallerylocation)" }
+    ]
+}
+"@
+        WhenInstalling
+        ThenInstalled @{ 'Carbon' = @('2.11.1', '2.11.0') }
+    }
+
+    It 'should install PackageManagement and PowerShellGet' {
+        GivenPxGetFile '{}'
+        # Has to be the same version as used by PxGet internally.
+        $pkgMgmtVersion = 
+            Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\PxGet\Modules\PackageManagement') |
+            Select-Object -ExpandProperty 'Name'
+        $psGetVersion = 
+            Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\PxGet\Modules\PowerShellGet') |
+            Select-Object -ExpandProperty 'Name'
+        GivenLockFile @"
+{
+    "PSModules": [
+        { "name": "PackageManagement", "version": "$($pkgMgmtVersion)", "location": "$($script:psgalleryLocation)" },
+        { "name": "PowerShellGet", "version": "$($psGetVersion)", "location": "$($script:psgalleryLocation)" }
+    ]
+}
+"@
+        WhenInstalling
+        ThenInstalled @{ 'PackageManagement' = $pkgMgmtVersion ; 'PowerShellGet' = $psGetVersion ; }
+    }
+
+    It 'should pass and install to custom PSModules directory' {
+        GivenPxGetFile @'
+        {
+            "PSModules": [
+                {
+                    "Name": "NoOp",
+                    "Version": "1.0.0"
+                }
+            ],
+            "PSModulesDirectoryName": "Modules"
+        }
+'@
+        GivenLockFile $script:latestNoOpLockFile
+        WhenInstalling
+        ThenInstalled @{ 'NoOp' = '1.0.0' } -In 'Modules'
+    }
+
+    It 'should install prerelease versions' {
+        GivenPxGetFile '{}'
+        GivenLockFile ('{ "PSModules": { "name": "NoOp", "version": "1.0.0-alpha26", ' +
+                      """location"": ""$($script:psgallerylocation)"" } }")
+        WhenInstalling
+        ThenInstalled @{ 'NoOp' = @('1.0.0-alpha26') }
+    }
+
+    It 'should install multiple modules' {
+        GivenPxGetFile '{}'
+        GivenLockFile ("{ ""PSModules"": [ " +
+            "{ ""name"": ""NoOp"", ""version"": ""1.0.0"", ""location"": ""$($script:psgallerylocation)"" }, " +
+            "{ ""name"": ""Carbon"", ""version"": ""2.11.0"", ""location"": ""$($script:psgallerylocation)"" }" +
+        "] }")
+        WhenInstalling
+        ThenInstalled @{ 'NoOp' = '1.0.0' ; 'Carbon' = '2.11.0' ; }
+    }
+
+    It 'should handle empty lock file' {
+        GivenPxGetFile '{}'
+        GivenLockFile '{}'
+        WhenInstalling
+        ThenSucceeded
+        ThenInstalled @{}
+    }
+
+    It 'should turn off verbose output in package management modules' {
+        GivenPxGetFile '{}'
+        GivenLockFile $script:latestNoOpLockFile
+        $env:PXGET_DISABLE_DEEP_VERBOSE = 'True'
+        $Global:VerbosePreference = [Management.Automation.ActionPreference]::Continue
+        $output = WhenInstalling 4>&1
+        $output | Write-Verbose -Verbose
+        # From Import-Module.
+        $output |
+            Where-Object { $_ -like 'Loading module from path ''*PackageManagement.psd1''.' } |
+            Should -BeNullOrEmpty
+        $output |
+            Where-Object { $_ -like 'Loading module from path ''*PowerShellGet.psd1''.' } |
+            Should -BeNullOrEmpty
+        # From PackageManagement.
+        $output |
+            Where-Object { $_ -like 'Using the provider ''PowerShellGet'' for searching packages.' } |
+            Should -BeNullOrEmpty
+        # From PowerShellGet.
+        $output |
+            Where-Object { $_ -like 'Module ''NoOp'' was saved successfully to path ''*''.' } |
+            Should -BeNullOrEmpty
+    }
+
+
+    It 'should turn off debug output in package management modules' {
+        GivenPxGetFile '{}'
+        GivenLockFile $script:latestNoOpLockFile
+        $env:PXGET_DISABLE_DEEP_DEBUG = 'True'
+        $Global:DebugPreference = [Management.Automation.ActionPreference]::Continue
+        $output = WhenInstalling 5>&1
+        $output | Write-Verbose -Verbose
+        # Import-Module doesn't output any debug messages.
+        # Save-Module does.
+        # From PowerShellGet. Can't find PackageManagement-only debug messages.
+        $output |
+            Where-Object { $_ -like '*PackagePRovider::FindPackage with name NoOp' } |
+            Should -BeNullOrEmpty
+    }
+}

--- a/Tests/lock.Tests.ps1
+++ b/Tests/lock.Tests.ps1
@@ -1,0 +1,231 @@
+
+#Requires -Version 5.1
+Set-StrictMode -Version 'Latest'
+
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+
+    $script:testRoot  = $null
+    $script:testNum = 0
+    $script:latestNoOpModule = Find-Module -Name 'NoOp' | Select-Object -First 1
+    $script:psgalleryLocation = Get-PSRepository -Name 'PSGallery' | Select-Object -ExpandProperty 'SourceLocation'
+
+    function GivenPxGetFile
+    {
+        param(
+            [Parameter(Mandatory, Position=0)]
+            [string] $Contents,
+
+            [String] $At = 'pxget.json'
+        )
+
+        $directory = $At | Split-Path -Parent
+        if( $directory )
+        {
+            New-Item -Path $directory -ItemType 'Directory' -Force | Out-Null
+        }
+
+        New-Item -Path $testRoot  -ItemType 'File' -Name $At -Value $Contents
+    }
+
+    function ThenLockFileIs
+    {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory, Position=0)]
+            [Object] $ExpectedConfiguration,
+
+            [String] $In = $script:testRoot
+        )
+
+        $path = Join-Path -Path $In -ChildPath 'pxget.lock.json'
+        $path | Should -Exist
+        # ConvertTo-Json behaves differently across platforms and versions.
+        Get-Content -Raw -Path $path | Should -Be ($ExpectedConfiguration | ConvertTo-Json)
+    }
+
+    function WhenLocking
+    {
+        [CmdletBinding()]
+        param(
+            [switch] $Recursively
+        )
+
+        $optionalParams = @{}
+        if( $Recursively )
+        {
+            $optionalParams['Recurse'] = $true
+        }
+        $result = Invoke-PxGet -Command 'update' @optionalParams
+        $result | Out-String | Write-Verbose -Verbose
+    }
+}
+
+Describe 'pxget update' {
+    BeforeEach { 
+        $script:testRoot = $null
+        $script:testRoot = Join-Path -Path $TestDrive -ChildPath ($script:testNum++)
+        New-Item -Path $script:testRoot -ItemType 'Directory'
+        $Global:Error.Clear()
+        Push-Location $script:testRoot
+    }
+
+    AfterEach {
+        Pop-Location
+    }
+
+    It 'should resolve exact versions' {
+        GivenPxGetFile @'
+{
+    "PSModules": [
+        { "Name": "Carbon", "Version": "2.11.1" },
+        { "Name": "NoOp", "Version": "1.0.0" }
+    ]
+}
+'@
+        WhenLocking
+        ThenLockFileIs ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'Carbon';
+                    version = '2.11.1';
+                    location = $script:psgalleryLocation;
+                },
+                [pscustomobject]@{
+                    name ='NoOp';
+                    version = '1.0.0';
+                    location = $script:psgalleryLocation;
+                }
+            );
+        })
+    }
+
+    It 'should resolve latest version by default' {
+        GivenPxGetFile @'
+    {
+        "PSModules": [ { "Name": "NoOp" }]
+    }
+'@
+        WhenLocking
+        ThenLockFileIs ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'NoOp';
+                    version = $script:latestNoOpModule.Version;
+                    location = $script:psgalleryLocation;
+                 }
+            )
+        })
+    }
+
+    It 'should resolve wildcards' {
+        GivenPxGetFile @'
+{
+    "PSModules": [
+        { "Name": "NoOp", "Version": "1.*" }
+    ]
+}
+'@
+        WhenLocking
+        $expectedModule =
+            Find-Module -Name 'NoOp' -AllVersions | Where-Object 'Version' -like '1.*' | Select-Object -First 1
+        ThenLockFileIs ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'NoOp';
+                    version = $expectedModule.Version;
+                    location = $script:psgalleryLocation;
+                }
+            )
+        })
+    }
+
+    It 'should automatically allow prerelease versions' {
+        GivenPxGetFile @'
+{
+    "PSModules": [
+        { "Name": "Carbon", "Version": "2.*-*" }
+    ]
+}
+'@
+        WhenLocking
+        ThenLockFileIs ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'Carbon';
+                    version = '2.11.1-alpha732';
+                    location = $script:psgalleryLocation;
+                }
+            )
+        })
+    }
+
+    It 'should allow user to enable prerelease versions' {
+        GivenPxGetFile @'
+{
+    "PSModules": [
+        { "Name": "Carbon", "Version": "*alpha732", "AllowPrerelease": true }
+    ]
+}
+'@
+        WhenLocking
+        ThenLockFileIs ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'Carbon';
+                    version = '2.11.1-alpha732';
+                    location = $script:psgalleryLocation;
+                }
+            )
+        })
+    }
+
+    It 'should lock recursively' {
+        GivenPxGetFile -At 'dir1\pxget.json' @'
+{
+    "PSModules": [
+        { "Name": "NoOp" }
+    ]
+}
+'@
+        GivenPxGetFile -At 'dir1\dir2\pxget.json' @'
+{
+    "PSModules": [
+        { "Name": "NoOp" }
+    ]
+}
+'@
+        WhenLocking -Recursively
+        $expectedLock = [pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'NoOp';
+                    version = $script:latestNoOpModule.Version;
+                    location = $script:psgalleryLocation;
+                 }
+            )
+        } 
+        ThenLockFileIs $expectedLock -In 'dir1'
+        ThenLockFileIs $expectedLock -In 'dir1\dir2'
+    }
+
+    It 'should clobber existing lock file' {
+        GivenPxGetFile @'
+    {
+        "PSModules": [ { "Name": "NoOp" }]
+    }
+'@
+        'clobberme' | Set-Content -Path 'pxget.lock.json'
+        WhenLocking
+        Get-Content -Path 'pxget.lock.json' -Raw | Should -Not -Match 'clobberme'
+        ThenLockFileIs ([pscustomobject]@{
+            PSModules = @(
+                [pscustomobject]@{
+                    name = 'NoOp';
+                    version = $script:latestNoOpModule.Version;
+                    location = $script:psgalleryLocation;
+                 }
+            )
+        })
+    }
+}


### PR DESCRIPTION
* Created a lock command that calls resolves versions in "pxget.json" to specific versions for the install command so
  the install command only needs to call Save-Module.
* pxget will now recursively find and work with pxget.json files.
* Added `FileName" parameter to allow customizing the pxget.json file name.